### PR TITLE
Added options.gitRange

### DIFF
--- a/tasks/changelog.js
+++ b/tasks/changelog.js
@@ -23,7 +23,7 @@ module.exports = function (grunt) {
 				change: '  - {{change}}\n',
 				empty: '  (none)\n'
 			},
-			gitRange: undefined
+			gitRange: {}
 		});
 
 		if (!options.after)
@@ -31,6 +31,9 @@ module.exports = function (grunt) {
 
 		if (!options.before)
 			options.before = moment().format();
+			
+		if (!options.gitRange.before)
+			options.gitRange.before = 'HEAD';
 
 		grunt.verbose.writeflags(options, 'Options');
 
@@ -105,11 +108,7 @@ module.exports = function (grunt) {
 			'--before="' + options.before + '"'
 		];
 		
-		if (options.gitRange) {
-			if (!options.gitRange.before) {
-				options.gitRange.before = 'HEAD';
-			}
-			
+		if (options.gitRange.after) {
 			args = [
 				'log',
 				options.gitRange.after + '..' + options.gitRange.before,


### PR DESCRIPTION
Fixes issue #3: Allow 'after' and 'before' to be git tags
### Usage

If `options.gitRange.after` is defined, `options.before` and `options.after` will be ignored.
#### options.gitRange.after

Type: `string`
Default value: `undefined`

The commit SHA1 value or tag where the log will start at.
#### options.gitRange.before

Type: `string`
Default value: `HEAD`

The commit SHA1 value or tag where the log will end at.

Example:

```
grunt.initConfig({
  changelog: {
    sample: {
      options: {
        gitRange: {
          after: "commit SHA / tag",
          before: "commit SHA / tag"
        }
      }
    }
  },
})

```
