### PR TITLE
Optionally pass after and before as arguments. Fixes #8.

### DIFF
--- a/tasks/changelog.js
+++ b/tasks/changelog.js
@@ -13,13 +13,15 @@ module.exports = function (grunt) {
 	var Handlebars = require('handlebars');
 	var moment = require('moment');
 
-	grunt.registerMultiTask('changelog', 'Generate a changelog based on commit messages.', function () {
+	grunt.registerMultiTask('changelog', 'Generate a changelog based on commit messages.', function (after, before) {
 		// Merge task-specific and/or target-specific options with these defaults.
 		var options = this.options({
 			featureRegex: /^(.*)closes #\d+:?(.*)$/gim,
 			fixRegex: /^(.*)fixes #\d+:?(.*)$/gim,
 			dest: 'changelog.txt',
-			template: '{{> features}}{{> fixes}}'
+			template: '{{> features}}{{> fixes}}',
+			after: after,
+			before: before
 		});
 
 		// Extend partials separately so only one custom partial can be specified


### PR DESCRIPTION
Allows to pass `after` and `before` as task arguments, e.g.:

``` shell
grunt changelog:sample:2013-03-01
grunt changelog:sample:2013-03-01:2013-04-01
```

Will come in handy once PR #7 is merged in. E.g.

``` shell
grunt changelog:sample:0.3.7
```
