### PR TITLE
Optionally prepend or append the changelog.  Fixes #5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 tmp/
 npm-debug.log
+*.swp

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -62,6 +62,38 @@ module.exports = function (grunt) {
           log: 'test/fixtures/log_fixes_only',
           dest: 'tmp/changelog_empty'
         }
+      },
+
+      prepend_prime: {
+        options: {
+          log: 'test/fixtures/log',
+          dest: 'tmp/changelog_prepend',
+          insertType: 'prepend'
+        }
+      },
+
+      prepend: {
+        options: {
+          log: 'test/fixtures/log_insert_type',
+          dest: 'tmp/changelog_prepend',
+          insertType: 'prepend'
+        }
+      },
+
+      append_prime: {
+        options: {
+          log: 'test/fixtures/log',
+          dest: 'tmp/changelog_append',
+          insertType: 'append'
+        }
+      },
+
+      append: {
+        options: {
+          log: 'test/fixtures/log_insert_type',
+          dest: 'tmp/changelog_append',
+          insertType: 'append'
+        }
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ Default value: `changelog`
 
 The file path to write the changelog to.
 
+#### options.insertType
+Type: `String`
+Default value: `undefined`
+
+Can be set to `prepend`, or `append`.  This will prepend / append the changelog to the file set by `options.dest`.  If nothing is set, the `options.dest` file will be overwritten.
+
 #### options.template
 Type: `String`
 Default value: `{{> features}}{{> fixes}}`

--- a/tasks/changelog.js
+++ b/tasks/changelog.js
@@ -101,6 +101,23 @@ module.exports = function (grunt) {
 
     // Write the changelog to the destination file.
     function writeChangelog(changelog) {
+
+      if (options.insertType && grunt.file.exists(options.dest)) {
+        var fileContents = grunt.file.read(options.dest);
+
+        switch (options.insertType) {
+          case 'prepend':
+            changelog = changelog + '\n' + fileContents;
+            break;
+          case 'append':
+            changelog = fileContents + '\n' + changelog;
+            break;
+          default:
+            grunt.fatal('"' + options.insertType + '" is not a valid insertType. Please use "append" or "prepend".');
+            return false;
+        }
+      }
+
       grunt.file.write(options.dest, changelog);
 
       // Log the results.

--- a/test/changelog_test.js
+++ b/test/changelog_test.js
@@ -61,5 +61,25 @@ exports.changelog = {
     test.equal(actual, expected, 'The empty partial in options should be used in the changelog.');
 
     test.done();
-  }
+  },
+
+  prepend: function (test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/changelog_prepend');
+    var expected = grunt.file.read('test/expected/prepend');
+    test.equal(actual, expected, 'The changelog should be prepended.');
+
+    test.done();
+  },
+
+  append: function (test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/changelog_append');
+    var expected = grunt.file.read('test/expected/append');
+    test.equal(actual, expected, 'The changelog should be appended.');
+
+    test.done();
+  },
 };

--- a/test/expected/append
+++ b/test/expected/append
@@ -1,0 +1,19 @@
+NEW:
+
+  - Feature 1 2 3.
+  - Feature 4 5 6.
+  - Feature 7 8 9.
+
+FIXES:
+
+  - Fix 1 2 3.
+  - Fix 4 5 6.
+  - Fix 7 8 9.
+
+NEW:
+
+  - Feature a b c.
+
+FIXES:
+
+  - Fix a b c.

--- a/test/expected/prepend
+++ b/test/expected/prepend
@@ -1,0 +1,19 @@
+NEW:
+
+  - Feature a b c.
+
+FIXES:
+
+  - Fix a b c.
+
+NEW:
+
+  - Feature 1 2 3.
+  - Feature 4 5 6.
+  - Feature 7 8 9.
+
+FIXES:
+
+  - Fix 1 2 3.
+  - Fix 4 5 6.
+  - Fix 7 8 9.

--- a/test/fixtures/log_insert_type
+++ b/test/fixtures/log_insert_type
@@ -1,0 +1,2 @@
+Fix a b c. fixes #411
+Feature a b c. closes #411


### PR DESCRIPTION
Example usage:

```
options: {
  insertType: 'prepend'
}
```
