### PR TITLE
Add new option `logArguments`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -106,6 +106,25 @@ module.exports = function (grunt) {
           dest: 'tmp/changelog_append',
           insertType: 'append'
         }
+      },
+
+      log_arguments: {
+        options: {
+          logArguments: [
+            '--pretty=* %h - %ad: %s',
+            '--no-merges',
+            '--date=short'
+          ],
+          dest: 'tmp/changelog_logArguments',
+          template: '[date]\n\n{{> features}}',
+          after: '2014-04-08',
+          before: '2014-08-21',
+          featureRegex: /^(.*)$/gim,
+          partials: {
+            features: '{{#if features}}{{#each features}}{{> feature}}{{/each}}{{else}}{{> empty}}{{/if}}\n',
+            feature: '- {{this}} {{this.date}}\n'
+          }
+        }
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ Default value: `'  (none)\n'`
 
 The Handlebars partial used by features or fixes when there are no changes.
 
+#### options.logArguments
+Type: `Array`
+Default value: `['--pretty=format:%s', '--no-merges']`
+
+See <http://git-scm.com/book/en/Git-Basics-Viewing-the-Commit-History>
+
 ### Usage Examples
 
 #### Default Options
@@ -264,6 +270,40 @@ release-notes/1.0.0.txt
 [NEW] Feature 3
 [FIX] Fix 1
 [FIX] Fix 2
+```
+
+#### Custom `git log` arguments
+
+The following example generates a simple changelog without separation of Commit types.
+
+```js
+grunt.initConfig({
+  changelog: {
+    sample: {
+      options: {
+        logArguments: [
+          '--pretty=* %h - %ad: %s',
+          '--no-merges',
+          '--date=short'
+        ],
+        template: '{{> features}}',
+        featureRegex: /^(.*)$/gim,
+        partials: {
+          features: '{{#if features}}{{#each features}}{{> feature}}{{/each}}{{else}}{{> empty}}{{/if}}\n',
+          feature: '- {{this}} {{this.date}}\n'
+        }
+      }
+    }
+  },
+})
+```
+
+changelog.txt
+
+```
+* c0d309b - 2014-08-20: Fix typo in readme. 
+* 7d84867 - 2014-04-11: Bumped to 0.2.2 
+* 2280e9c - 2014-04-07: Optionally prepend or append the changelog.  Fixes #5
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -105,11 +105,9 @@ The Handlebars partial used for the list of features.
 
 #### options.partials.feature
 Type: `String`
-Default value: `'  - {{this}}\n'`
+Default value: `'  - {{{this}}}\n'`
 
 The Handlebars partial used for each individual feature.
-
-*Please note that you should use the "triple-stash" `{{{`, if you don't want Handlebars to escape special characters like `&`, `<`, `>`, `"`, `'`, `` ` `` which might be existing in your commit messages. See [here](http://handlebarsjs.com/#html-escaping) and [here](http://handlebarsjs.com/util.html#utils-escapeExpression).*
 
 #### options.partials.fixes
 Type: `String`
@@ -119,9 +117,7 @@ The Handlebars partial used for the list of fixes.
 
 #### options.partials.fix
 Type: `String`
-Default value: `'  - {{this}}\n'`
-
-*Please note that you should use the "triple-stash" `{{{`, if you don't want Handlebars to escape special characters like `&`, `<`, `>`, `"`, `'`, `` ` `` which might be existing in your commit messages. See [here](http://handlebarsjs.com/#html-escaping) and [here](http://handlebarsjs.com/util.html#utils-escapeExpression).*
+Default value: `'  - {{{this}}}\n'`
 
 The Handlebars partial used for each individual fix.
 

--- a/tasks/changelog.js
+++ b/tasks/changelog.js
@@ -28,9 +28,9 @@ module.exports = function (grunt) {
     // without having to provide every single partial.
     var partials = _.extend({
       features: 'NEW:\n\n{{#if features}}{{#each features}}{{> feature}}{{/each}}{{else}}{{> empty}}{{/if}}\n',
-      feature: '  - {{this}}\n',
+      feature: '  - {{{this}}}\n',
       fixes: 'FIXES:\n\n{{#if fixes}}{{#each fixes}}{{> fix}}{{/each}}{{else}}{{> empty}}{{/if}}',
-      fix: '  - {{this}}\n',
+      fix: '  - {{{this}}}\n',
       empty: '  (none)\n'
     }, options.partials);
 

--- a/tasks/changelog.js
+++ b/tasks/changelog.js
@@ -141,12 +141,18 @@ module.exports = function (grunt) {
 
     var done = this.async();
 
-    // Build our options for the git log command. Only print the commit message.
-    var args = [
-      'log',
-      '--pretty=format:%s',
-      '--no-merges'
-    ];
+    // Build our options for the git log command.
+    // Default: Only print the commit message.
+    var args = ['log'];
+
+    if (options.logArguments) {
+      args.push.apply(args, options.logArguments);
+    } else {
+      args.push(
+        '--pretty=format:%s',
+        '--no-merges'
+      );
+    }
 
     if (isDateRange) {
       args.push('--after="' + after.format() + '"');

--- a/test/changelog_test.js
+++ b/test/changelog_test.js
@@ -83,6 +83,16 @@ exports.changelog = {
     test.done();
   },
 
+  logArguments: function (test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/changelog_logArguments');
+    var expected = grunt.file.read('test/expected/logArguments');
+    test.equal(actual, expected, 'The commit messages should have a custom format defined by log arguments.');
+
+    test.done();
+  },
+
   specialchars: function (test) {
     test.expect(1);
 

--- a/test/expected/logArguments
+++ b/test/expected/logArguments
@@ -1,0 +1,6 @@
+[date]
+
+- * c0d309b - 2014-08-20: Fix typo in readme. 
+- * 7d84867 - 2014-04-11: Bumped to 0.2.2 
+- * 2280e9c - 2014-04-07: Optionally prepend or append the changelog.  Fixes #5 
+


### PR DESCRIPTION
Makes it possible to go crazy with formatting the git log.

Example log output:

    b5873bd - 2014-07-03: i18n for dataTables.
    be90085 - 2014-07-03: Enhance styling of bootstrap dataTables.

which is accomplished with the following git log command:

    git log --pretty="* %h - %ad: %s" [tag]..[tag] --no-merges --date=short

Implemented by:

* Keeping the old log arguments as default.
* Add example task using the `logArguments` option.
* Add test.

Closes #15