### PR TITLE
Add new option `fileHeader`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -94,7 +94,52 @@ module.exports = function (grunt) {
           dest: 'tmp/changelog_append',
           insertType: 'append'
         }
+      },
+
+      file_header: {
+        options: {
+          log: 'test/fixtures/log',
+          dest: 'tmp/changelog_fileHeader',
+          fileHeader: '# Changelog'
+        }
+      },
+
+      file_header_prepend_prime: {
+        options: {
+          log: 'test/fixtures/log',
+          dest: 'tmp/changelog_fileHeader_prepend',
+          insertType: 'prepend',
+          fileHeader: '# Changelog'
+        }
+      },
+
+      file_header_prepend: {
+        options: {
+          log: 'test/fixtures/log_insert_type',
+          dest: 'tmp/changelog_fileHeader_prepend',
+          insertType: 'prepend',
+          fileHeader: '# Changelog'
+        }
+      },
+
+      file_header_append_prime: {
+        options: {
+          log: 'test/fixtures/log',
+          dest: 'tmp/changelog_fileHeader_append',
+          insertType: 'append',
+          fileHeader: '# Changelog'
+        }
+      },
+
+      file_header_append: {
+        options: {
+          log: 'test/fixtures/log_insert_type',
+          dest: 'tmp/changelog_fileHeader_append',
+          insertType: 'append',
+          fileHeader: '# Changelog'
+        }
       }
+
     },
 
     nodeunit: {

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ FIXES:
 
 ### Options
 
+####options.fileHeader
+Type: `String`
+Default value: `undefined `
+
+The string will be placed on top of the changelog. 
+
 #### options.after
 Type: `String`
 Default value: `7 days ago`
@@ -155,6 +161,38 @@ FIXES:
   - Fix 1
   - Fix 2
 ```
+
+#### File header
+This examples uses the option `fileHeader` to prepend a custom string to the changelog.
+
+```js
+grunt.initConfig({
+  changelog: {
+    sample: {
+      options: {
+       fileHeader: '# Changelog'
+      }
+    }
+  },
+})
+```
+
+changelog.txt
+```
+# Changelog
+
+NEW:
+
+  - Feature 1
+  - Feature 2
+  - Feature 3
+
+FIXES:
+
+  - Fix 1
+  - Fix 2
+```
+
 
 #### Custom Range
 In this example, a custom date range is used to only show changes between March 1st and March 14th.

--- a/tasks/changelog.js
+++ b/tasks/changelog.js
@@ -34,8 +34,6 @@ module.exports = function (grunt) {
       empty: '  (none)\n'
     }, options.partials);
 
-    var after;
-    var before;
     var isDateRange;
 
     // Determine if a date or a commit sha / tag was provided for the after
@@ -101,9 +99,15 @@ module.exports = function (grunt) {
 
     // Write the changelog to the destination file.
     function writeChangelog(changelog) {
+      var fileContents = null;
+      var firstLineFile = null;
+      var firstLineFileHeader = null;
+      var regex = null;
 
       if (options.insertType && grunt.file.exists(options.dest)) {
-        var fileContents = grunt.file.read(options.dest);
+        fileContents = grunt.file.read(options.dest);
+        firstLineFile = fileContents.split('\n')[0];
+        grunt.log.debug('firstLineFile = ' + firstLineFile);
 
         switch (options.insertType) {
           case 'prepend':
@@ -117,6 +121,28 @@ module.exports = function (grunt) {
             return false;
         }
       }
+
+      if (options.fileHeader) {
+        firstLineFileHeader = options.fileHeader.split('\n')[0];
+        grunt.log.debug('firstLineFileHeader = ' + firstLineFileHeader);
+
+        if (options.insertType === 'prepend') {
+          if (firstLineFile !== firstLineFileHeader) {
+            changelog = options.fileHeader + '\n\n' + changelog;
+          } else {
+            regex = new RegExp(options.fileHeader+'\n\n','m');
+            changelog = options.fileHeader + '\n\n' + changelog.replace(regex, '');
+          }
+
+        // insertType === 'append' || undefined
+        } else {
+          if (firstLineFile !== firstLineFileHeader) {
+            changelog = options.fileHeader + '\n\n' + changelog;
+          }
+        }
+
+      }
+
 
       grunt.file.write(options.dest, changelog);
 

--- a/test/changelog_test.js
+++ b/test/changelog_test.js
@@ -82,4 +82,35 @@ exports.changelog = {
 
     test.done();
   },
+
+  fileHeader: function (test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/changelog_fileHeader');
+    var expected = grunt.file.read('test/expected/fileHeader');
+    test.equal(actual, expected, 'The file header should be added on top of the file.');
+
+    test.done();
+  },
+
+  fileHeader_prepend: function (test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/changelog_fileHeader_prepend');
+    var expected = grunt.file.read('test/expected/fileHeader_prepend');
+    test.equal(actual, expected, 'The file header should be added on top of the file.');
+
+    test.done();
+  },
+
+  fileHeader_append: function (test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/changelog_fileHeader_append');
+    var expected = grunt.file.read('test/expected/fileHeader_append');
+    test.equal(actual, expected, 'The file header should be added on top of the file.');
+
+    test.done();
+  }
+
 };

--- a/test/expected/fileHeader
+++ b/test/expected/fileHeader
@@ -1,0 +1,13 @@
+# Changelog
+
+NEW:
+
+  - Feature 1 2 3.
+  - Feature 4 5 6.
+  - Feature 7 8 9.
+
+FIXES:
+
+  - Fix 1 2 3.
+  - Fix 4 5 6.
+  - Fix 7 8 9.

--- a/test/expected/fileHeader_append
+++ b/test/expected/fileHeader_append
@@ -1,0 +1,21 @@
+# Changelog
+
+NEW:
+
+  - Feature 1 2 3.
+  - Feature 4 5 6.
+  - Feature 7 8 9.
+
+FIXES:
+
+  - Fix 1 2 3.
+  - Fix 4 5 6.
+  - Fix 7 8 9.
+
+NEW:
+
+  - Feature a b c.
+
+FIXES:
+
+  - Fix a b c.

--- a/test/expected/fileHeader_prepend
+++ b/test/expected/fileHeader_prepend
@@ -1,0 +1,21 @@
+# Changelog
+
+NEW:
+
+  - Feature a b c.
+
+FIXES:
+
+  - Fix a b c.
+
+NEW:
+
+  - Feature 1 2 3.
+  - Feature 4 5 6.
+  - Feature 7 8 9.
+
+FIXES:
+
+  - Fix 1 2 3.
+  - Fix 4 5 6.
+  - Fix 7 8 9.


### PR DESCRIPTION
It would be awesome to make it possible to define a file header like the following example.

    option.fileHeader: '# Changelog'

This is accomplished: 

* Add example tasks using the `fileHeader ` option.
* Add tests.
* Update readme.

The code is a bit ugly because it needs to handle `options.insertType === 'prepend'`.
I could have moved the handling to the `case 'prepend':` ([L113](https://github.com/ericmatthys/grunt-changelog/pull/18/files#diff-3e81f8611acaed53f40d1a3e5934e6b7R113)) and get rid of that regexp. But that has its own ugliness because then my code would be cluttered all over `function writeChangelog()`.

So I guess ist better to have all code related to `option.fileHeader` in a single condition like:
````
if (options.fileHeader) { 
  // do stuff
}
````

Closes #14 