### PR TITLE
Feature/html entities

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,6 +48,13 @@ module.exports = function (grunt) {
         }
       },
 
+      formatting_options_specialchars: {
+        options: {
+          log: 'test/fixtures/log_specialchars',
+          dest: 'tmp/changelog_formatting_specialchars'
+        }
+      },
+
       regex_options: {
         options: {
           log: 'test/fixtures/log',

--- a/tasks/changelog.js
+++ b/tasks/changelog.js
@@ -28,14 +28,12 @@ module.exports = function (grunt) {
     // without having to provide every single partial.
     var partials = _.extend({
       features: 'NEW:\n\n{{#if features}}{{#each features}}{{> feature}}{{/each}}{{else}}{{> empty}}{{/if}}\n',
-      feature: '  - {{this}}\n',
+      feature: '  - {{{this}}}\n',
       fixes: 'FIXES:\n\n{{#if fixes}}{{#each fixes}}{{> fix}}{{/each}}{{else}}{{> empty}}{{/if}}',
-      fix: '  - {{this}}\n',
+      fix: '  - {{{this}}}\n',
       empty: '  (none)\n'
     }, options.partials);
 
-    var after;
-    var before;
     var isDateRange;
 
     // Determine if a date or a commit sha / tag was provided for the after

--- a/test/changelog_test.js
+++ b/test/changelog_test.js
@@ -82,4 +82,14 @@ exports.changelog = {
 
     test.done();
   },
+
+  specialchars: function (test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/changelog_formatting_specialchars');
+    var expected = grunt.file.read('test/expected/specialchars');
+    test.equal(actual, expected, 'Special chars shouldn’t be replaced by HTML entities.');
+
+    test.done();
+  },
 };

--- a/test/expected/specialchars
+++ b/test/expected/specialchars
@@ -1,0 +1,11 @@
+NEW:
+
+  - Feature 1, 2 & 3.
+  - Feature 4 < 5 .
+  - Feature 7 > 8 > 9.
+
+FIXES:
+
+  - Fix `1` `2` `3`.
+  - Fix "4" "5" "6".
+  - Fix '7', '8', '9'.

--- a/test/fixtures/log_specialchars
+++ b/test/fixtures/log_specialchars
@@ -1,0 +1,6 @@
+Fix `1` `2` `3`. fixes #410
+Fix "4" "5" "6". Fixes #410
+fixes #410 Fix '7', '8', '9'.
+Feature 1, 2 & 3. closes #410
+Feature 4 < 5 . Closes #410
+closes #410 Feature 7 > 8 > 9.


### PR DESCRIPTION
Just as described in #12 it should be explained how the prevent the escaping of html special chars which might be contained in your commit messages. 

This pull request contains additions in the `README.md` to accomplish this. 

In addition it adds a test. Just cherrypick the commit (89ee96e) which updates the readme if you don’t feel the need for the test :octocat: 
