### PR TITLE
fixes #21: one can now specify a single commit instead of before/after

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -106,6 +106,12 @@ module.exports = function (grunt) {
           dest: 'tmp/changelog_append',
           insertType: 'append'
         }
+      },
+
+      initial_commit : {
+        options: {
+          commit: '0c3208b2bd268facec69eb5f1907a1f4a23c0d9f'
+        }
       }
     },
 

--- a/tasks/changelog.js
+++ b/tasks/changelog.js
@@ -38,9 +38,10 @@ module.exports = function (grunt) {
 
     // Determine if a date or a commit sha / tag was provided for the after
     // option. This will determine what kind of range we need to use.
-    var commit = options.commit;
-    if (!commit) {
-      if (options.after) {
+    if (options.after) {
+      if (options.after == 'commit') {
+        commmit = options.before;
+      } else {
         after = moment(options.after);
         isDateRange = after.isValid();
 
@@ -48,17 +49,17 @@ module.exports = function (grunt) {
         // likely means that a commit sha or tag is being used.
         if (!isDateRange)
           after = options.after;
-      } else {
-        // If no after option is provided, default to using the last week.
-        after = moment().subtract('days', 7);
-        isDateRange = true;
       }
+    } else {
+      // If no after option is provided, default to using the last week.
+      after = moment().subtract('days', 7);
+      isDateRange = true;
+    }
 
-      if (isDateRange) {
-        before = options.before ? moment(options.before) : moment();
-      } else {
-        before = options.before ? options.before : 'HEAD';
-      }
+    if (isDateRange) {
+      before = options.before ? moment(options.before) : moment();
+    } else {
+      before = options.before ? options.before : 'HEAD';
     }
 
     // Compile and register our templates and partials.

--- a/tasks/changelog.js
+++ b/tasks/changelog.js
@@ -34,6 +34,7 @@ module.exports = function (grunt) {
       empty: '  (none)\n'
     }, options.partials);
 
+    var commit;
     var isDateRange;
 
     // Determine if a date or a commit sha / tag was provided for the after

--- a/tasks/changelog.js
+++ b/tasks/changelog.js
@@ -38,24 +38,27 @@ module.exports = function (grunt) {
 
     // Determine if a date or a commit sha / tag was provided for the after
     // option. This will determine what kind of range we need to use.
-    if (options.after) {
-      after = moment(options.after);
-      isDateRange = after.isValid();
+    var commit = options.commit;
+    if (!commit) {
+      if (options.after) {
+        after = moment(options.after);
+        isDateRange = after.isValid();
 
-      // Fallback to the provided after value if it is not a valid date. This
-      // likely means that a commit sha or tag is being used.
-      if (!isDateRange)
-        after = options.after;
-    } else {
-      // If no after option is provided, default to using the last week.
-      after = moment().subtract('days', 7);
-      isDateRange = true;
-    }
+        // Fallback to the provided after value if it is not a valid date. This
+        // likely means that a commit sha or tag is being used.
+        if (!isDateRange)
+          after = options.after;
+      } else {
+        // If no after option is provided, default to using the last week.
+        after = moment().subtract('days', 7);
+        isDateRange = true;
+      }
 
-    if (isDateRange) {
-      before = options.before ? moment(options.before) : moment();
-    } else {
-      before = options.before ? options.before : 'HEAD';
+      if (isDateRange) {
+        before = options.before ? moment(options.before) : moment();
+      } else {
+        before = options.before ? options.before : 'HEAD';
+      }
     }
 
     // Compile and register our templates and partials.
@@ -152,7 +155,12 @@ module.exports = function (grunt) {
       args.push('--after="' + after.format() + '"');
       args.push('--before="' + before.format() + '"');
     } else {
-      args.splice(1, 0, after + '..' + before);
+      if (commit) {
+        args.splice(1, 0, commit);
+      }
+      else {
+        args.splice(1, 0, after + '..' + before);
+      }
     }
 
     grunt.verbose.writeln('git ' + args.join(' '));

--- a/tasks/changelog.js
+++ b/tasks/changelog.js
@@ -41,7 +41,7 @@ module.exports = function (grunt) {
     // option. This will determine what kind of range we need to use.
     if (options.after) {
       if (options.after == 'commit') {
-        commmit = options.before;
+        commit = options.before;
       } else {
         after = moment(options.after);
         isDateRange = after.isValid();


### PR DESCRIPTION
Tested this and it works just fine, after a little while ,/

Added Gruntfile.js/changelog/initial_commit pointing to the initial commit for quick testing purposes.