### PR TITLE
Change default partials rendering the commit messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,9 @@ The Handlebars partial used for the list of features.
 
 #### options.partials.feature
 Type: `String`
-Default value: `'  - {{this}}\n'`
+Default value: `'  - {{{this}}}\n'`
 
 The Handlebars partial used for each individual feature.
-
-*Please note that you should use the "triple-stash" `{{{`, if you don't want Handlebars to escape special characters like `&`, `<`, `>`, `"`, `'`, `` ` `` which might be existing in your commit messages. See [here](http://handlebarsjs.com/#html-escaping) and [here](http://handlebarsjs.com/util.html#utils-escapeExpression).*
 
 #### options.partials.fixes
 Type: `String`
@@ -119,9 +117,7 @@ The Handlebars partial used for the list of fixes.
 
 #### options.partials.fix
 Type: `String`
-Default value: `'  - {{this}}\n'`
-
-*Please note that you should use the "triple-stash" `{{{`, if you don't want Handlebars to escape special characters like `&`, `<`, `>`, `"`, `'`, `` ` `` which might be existing in your commit messages. See [here](http://handlebarsjs.com/#html-escaping) and [here](http://handlebarsjs.com/util.html#utils-escapeExpression).*
+Default value: `'  - {{{this}}}\n'`
 
 The Handlebars partial used for each individual fix.
 

--- a/tasks/changelog.js
+++ b/tasks/changelog.js
@@ -28,9 +28,9 @@ module.exports = function (grunt) {
     // without having to provide every single partial.
     var partials = _.extend({
       features: 'NEW:\n\n{{#if features}}{{#each features}}{{> feature}}{{/each}}{{else}}{{> empty}}{{/if}}\n',
-      feature: '  - {{this}}\n',
+      feature: '  - {{{this}}}\n',
       fixes: 'FIXES:\n\n{{#if fixes}}{{#each fixes}}{{> fix}}{{/each}}{{else}}{{> empty}}{{/if}}',
-      fix: '  - {{this}}\n',
+      fix: '  - {{{this}}}\n',
       empty: '  (none)\n'
     }, options.partials);
 


### PR DESCRIPTION
Use the »triple-stash« `{{{` to prevent Handlebars to escape special characters like `&`, `<`, `>`, `"`, `'`, ````` which might be existing in your commit messages by default.

See: http://handlebarsjs.com/#html-escaping

Related to #12, #19