### PR TITLE
Add new option `logArguments`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -106,6 +106,25 @@ module.exports = function (grunt) {
           dest: 'tmp/changelog_append',
           insertType: 'append'
         }
+      },
+
+      log_arguments: {
+        options: {
+          logArguments: [
+            '--pretty=* %h - %ad: %s',
+            '--no-merges',
+            '--date=short'
+          ],
+          dest: 'tmp/changelog_logArguments',
+          template: '[date]\n\n{{> features}}',
+          after: '2014-04-08',
+          before: '2014-08-21',
+          featureRegex: /^(.*)$/gim,
+          partials: {
+            features: '{{#if features}}{{#each features}}{{> feature}}{{/each}}{{else}}{{> empty}}{{/if}}\n',
+            feature: '- {{this}} {{this.date}}\n'
+          }
+        }
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ Default value: `'  (none)\n'`
 
 The Handlebars partial used by features or fixes when there are no changes.
 
+#### options.logArguments
+Type: `Array`
+Default value: `['--pretty=format:%s', '--no-merges']`
+
+See <http://git-scm.com/book/en/Git-Basics-Viewing-the-Commit-History>
+
 ### Usage Examples
 
 #### Default Options
@@ -264,6 +270,40 @@ release-notes/1.0.0.txt
 [NEW] Feature 3
 [FIX] Fix 1
 [FIX] Fix 2
+```
+
+#### Custom `git log` arguments
+
+The following example generates a simple changelog without separation of Commit types.
+
+```js
+grunt.initConfig({
+  changelog: {
+    sample: {
+      options: {
+        logArguments: [
+          '--pretty=* %h - %ad: %s',
+          '--no-merges',
+          '--date=short'
+        ],
+        template: '{{> features}}',
+        featureRegex: /^(.*)$/gim,
+        partials: {
+          features: '{{#if features}}{{#each features}}{{> feature}}{{/each}}{{else}}{{> empty}}{{/if}}\n',
+          feature: '- {{this}} {{this.date}}\n'
+        }
+      }
+    }
+  },
+})
+```
+
+changelog.txt
+
+```
+* c0d309b - 2014-08-20: Fix typo in readme. 
+* 7d84867 - 2014-04-11: Bumped to 0.2.2 
+* 2280e9c - 2014-04-07: Optionally prepend or append the changelog.  Fixes #5
 ```
 
 ## Contributing

--- a/tasks/changelog.js
+++ b/tasks/changelog.js
@@ -141,12 +141,18 @@ module.exports = function (grunt) {
 
     var done = this.async();
 
-    // Build our options for the git log command. Only print the commit message.
-    var args = [
-      'log',
-      '--pretty=format:%s',
-      '--no-merges'
-    ];
+    // Build our options for the git log command.
+    // Default: Only print the commit message.
+    var args = ['log'];
+
+    if (options.logArguments) {
+      args.push.apply(args, options.logArguments);
+    } else {
+      args.push(
+        '--pretty=format:%s',
+        '--no-merges'
+      );
+    }
 
     if (isDateRange) {
       args.push('--after="' + after.format() + '"');

--- a/test/changelog_test.js
+++ b/test/changelog_test.js
@@ -83,6 +83,16 @@ exports.changelog = {
     test.done();
   },
 
+  logArguments: function (test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/changelog_logArguments');
+    var expected = grunt.file.read('test/expected/logArguments');
+    test.equal(actual, expected, 'The commit messages should have a custom format defined by log arguments.');
+
+    test.done();
+  },
+
   specialchars: function (test) {
     test.expect(1);
 

--- a/test/expected/logArguments
+++ b/test/expected/logArguments
@@ -1,0 +1,6 @@
+[date]
+
+- * c0d309b - 2014-08-20: Fix typo in readme. 
+- * 7d84867 - 2014-04-11: Bumped to 0.2.2 
+- * 2280e9c - 2014-04-07: Optionally prepend or append the changelog.  Fixes #5 
+


### PR DESCRIPTION
Continue #16 over here, because PRs should land in `develop` branch first.

----
Makes it possible to go crazy with formatting the git log.

Example log output:

    b5873bd - 2014-07-03: i18n for dataTables.
    be90085 - 2014-07-03: Enhance styling of bootstrap dataTables.

which is accomplished with the following git log command:

    git log --pretty="* %h - %ad: %s" [tag]..[tag] --no-merges --date=short

Implemented by:

* Keeping the old log arguments as default.
* Add example task using the `logArguments` option.
* Add test.

Closes #15