### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,18 +24,18 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "underscore": "~1.6.0",
+    "underscore": "~1.7.0",
     "handlebars": "~2.0.0",
-    "moment": "~2.0.0"
+    "moment": "~2.9.0"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.1.1",
-    "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-nodeunit": "~0.1.2",
-    "grunt": "~0.4.0"
+    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-clean": "~0.6.0",
+    "grunt-contrib-nodeunit": "~0.4.1",
+    "grunt": "~0.4.5"
   },
   "peerDependencies": {
-    "grunt": "~0.4.0"
+    "grunt": "~0.4.5"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
This PR updates:

- »underscore» from ~1.6.0 to ~1.7.0 
- »moment» from ~2.0.0 to ~2.9.0 
- »grunt-contrib-jshint» from ~0.1.1 to ~0.10.0 
- »grunt-contrib-clean» from ~0.4.0 to ~0.6.0 
- »grunt-contrib-nodeunit» from ~0.1.2 to ~0.4.1 
- »grunt» from ~0.4.0 to ~0.4.5 