### PR TITLE
Release 0.3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-  - '0.11'
-  - '0.10'
+  - '0.12'
+  - '4'
+  - '5'
 before_install:
   - currentfolder=${PWD##*/}
   - if [ "$currentfolder" != 'grunt-changelog' ]; then cd .. && eval "mv $currentfolder grunt-changelog" && cd grunt-changelog; fi

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "grunt": "~0.4.5"
   },
   "peerDependencies": {
-    "grunt": "~0.4.5"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin",

--- a/package.json
+++ b/package.json
@@ -14,26 +14,21 @@
   "bugs": {
     "url": "https://github.com/ericmatthys/grunt-changelog/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/ericmatthys/grunt-changelog/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "scripts": {
     "test": "grunt test"
   },
   "dependencies": {
-    "handlebars": "~2.0.0",
-    "moment": "~2.9.0",
-    "semver": "^4.3.4",
-    "underscore": "~1.7.0"
+    "handlebars": "~4.0.5",
+    "moment": "~2.12.0",
+    "semver": "^5.1.0",
+    "underscore": "~1.8.3"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.10.0",
-    "grunt-contrib-clean": "~0.6.0",
-    "grunt-contrib-nodeunit": "~0.4.1",
-    "grunt": "~0.4.5"
+    "grunt-contrib-jshint": "~1.0.0",
+    "grunt-contrib-clean": "~1.0.0",
+    "grunt-contrib-nodeunit": "~1.0.0",
+    "grunt": "~1.0.1"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-changelog",
   "description": "Generate a changelog based on commit messages.",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "homepage": "https://github.com/ericmatthys/grunt-changelog",
   "author": {
     "name": "Eric Matthys",


### PR DESCRIPTION
Basically fixing this peer dependency chaos when using Grunt in v1 with npm < 3
- 42b918af Update peerDependencies to support Grunt 1.0
- e222ab9f Update dependencies
- e166aa47 Run travis builds against Node v0.12, v4 and v5
- 24bc2a0a Bump Version to 0.3.2
