### PR TITLE
FIX Moment's Deprecation Warning also an infinity loop with the usage of @{push}.. in logArguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
   },
   "dependencies": {
     "handlebars": "~4.0.5",
-    "moment": "~2.12.0",
+    "moment": "^2.24.0",
     "semver": "^5.1.0",
-    "underscore": "~1.8.3"
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~1.0.0",

--- a/tasks/changelog.js
+++ b/tasks/changelog.js
@@ -42,7 +42,8 @@ module.exports = function (grunt) {
     if (options.after) {
 
       if (!semver.valid(options.after)) {
-        after = moment(options.after);
+        // after = moment(options.after);
+        after = moment().subtract(options.after, 'days');
         isDateRange = after.isValid();
       }
 

--- a/tasks/changelog.js
+++ b/tasks/changelog.js
@@ -52,7 +52,7 @@ module.exports = function (grunt) {
         after = options.after;
     } else {
       // If no after option is provided, default to using the last week.
-      after = moment().subtract('days', 7);
+      after = moment().subtract(7, 'days');
       isDateRange = true;
     }
 

--- a/tasks/changelog.js
+++ b/tasks/changelog.js
@@ -77,6 +77,10 @@ module.exports = function (grunt) {
       var changes = [];
       var match;
 
+      if ( !log.stdout ) {
+        return changes;
+      }
+
       while ((match = regex.exec(log))) {
         var change = '';
 


### PR DESCRIPTION
There is a deprecation warning as of v2.8.0 when using moment().subtract() shown in console when running `grunt changelog`.

Also if we want to changelog only commits which was not pushed to the origin I define the argument `@{push}..` in `logArguments`. But what happens if the branch is up-to-date with origin the log will be empty making an infinity loop and console running out of memory.